### PR TITLE
add: spinner in a form of three pulsating dots

### DIFF
--- a/frontend/src/components/WofSpinnerDots.vue
+++ b/frontend/src/components/WofSpinnerDots.vue
@@ -1,0 +1,95 @@
+<template>
+  <div v-if="loading" class="spinner" :style="spinnerStyle">
+    <div></div>
+    <div></div>
+    <div></div>
+  </div>
+</template>
+
+<script>
+/**
+ * Three pulsating dots in a row indicating a process is taking place.
+ * @displayName Dots Spinner
+ * @example
+ * <wof-spinner-dots :loading="true" />
+ */
+export default {
+  name: "WofSpinnerDots",
+  props: {
+    /**
+     * The boolean value indicating whether to show the spinner.
+     * If `true` then shows the spinner; otherwise doesn't show.
+     */
+    loading: {
+      type: String,
+      required: true,
+    },
+    /**
+     * The height of the spinner div. Its width is 3.3 times larger than
+     * the provided height.
+     */
+    size: {
+      type: Number,
+      default: 1
+    }
+  },
+  computed: {
+    /**
+     * The computed property dynamically calculating the sizes of the spinner elements.
+     * This allows the spinner to dynamically resize the shadows of the dots and the gap
+     * between them.
+     */
+    spinnerStyle() {
+      return "font-size: " + this.size + "rem;" +
+      "height: " + this.size + "rem;" +
+      "gap: " + this.size / 6 + "rem;";
+    }
+  }
+}
+</script>
+
+<style lang="less" scoped>
+@import './common.less';
+
+.spinner {
+  display: flex;
+  margin: 0;
+  aspect-ratio: 3.3 / 1;
+  align-content: center;
+  justify-content: center;
+}
+.spinner div {
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: linear-gradient(to bottom right, grey -50%, white);
+  box-shadow: 0.05em 0.05em 0.1em 0 hsl(0, 0%, 20%);
+  width: 33%;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+.spinner :nth-child(1) {
+  left: 0;
+}
+
+.spinner :nth-child(2) {
+  left: 33%;
+  animation-delay: 0.3s;
+}
+
+.spinner :nth-child(3) {
+  left: 66%;
+  animation-delay: 0.6s;
+}
+
+@keyframes pulse {
+  0% {
+    scale: 65%;
+  }
+  50% {
+    scale: 100%;
+  }
+  100% {
+    scale: 65%
+  }
+}
+</style>

--- a/frontend/src/components/WofSpinnerDots.vue
+++ b/frontend/src/components/WofSpinnerDots.vue
@@ -61,8 +61,8 @@ export default {
 .spinner div {
   aspect-ratio: 1;
   border-radius: 50%;
-  background: linear-gradient(to bottom right, grey -50%, white);
-  box-shadow: 0.05em 0.05em 0.1em 0 hsl(0, 0%, 20%);
+  background: linear-gradient(to bottom right, @primary-accent-color -40%, white);
+  box-shadow: 0.05em 0.05em 0.1em 0 hsl(0, 0%, 50%);
   width: 33%;
   animation: pulse 2s ease-in-out infinite;
 }
@@ -83,13 +83,13 @@ export default {
 
 @keyframes pulse {
   0% {
-    scale: 65%;
+    transform: scale(65%);
   }
   50% {
-    scale: 100%;
+    transform: scale(100%);
   }
   100% {
-    scale: 65%
+    transform: scale(65%);
   }
 }
 </style>

--- a/frontend/src/components/WofSpinnerDots.vue
+++ b/frontend/src/components/WofSpinnerDots.vue
@@ -21,7 +21,7 @@ export default {
      * If `true` then shows the spinner; otherwise doesn't show.
      */
     loading: {
-      type: String,
+      type: Boolean,
       required: true,
     },
     /**


### PR DESCRIPTION
Closes #73

I tested it out with this in app.vue:
```vue
<template>
  <main>
    <wof-header/>
    <div class="main-wrapper">
      <router-view msg="This is a basic frontend"></router-view>
      <wof-spinner-dots :loading="true" :size="0.4"></wof-spinner-dots>
    </div>
    <wof-footer/>
  </main>
</template>

<script>
import WofFooter from './components/WofFooter.vue';
import WofHeader from './components/WofHeader.vue';
import WofSpinnerDots from "./components/WofSpinnerDots.vue";

export default {
  components: { WofFooter, WofHeader, WofSpinnerDots },
  name: "App",
};
</script>

<style lang="less">
@import './components/common.less';
html {
  font-size: 16px;
}
body {
  margin: 0;
  box-sizing: border-box;

  main {
    font-family: Roboto;

    .main-wrapper {
      display: flex;
      flex-wrap: wrap;
      justify-content: center;
      min-height: 90vh;
      background-color: @tertiary-color;
      padding: 2em 4em;
    }
  }
}

</style>
```

I recommend tinkering with the values in loading and size. It should automatically scale the gaps and shadows between the dots. Dots should always be perfect circles. Something like this:
![image](https://user-images.githubusercontent.com/24480246/143661185-5cc9e12d-a7be-4c0a-b512-d750d83726de.png)


I have a bigger spinner in a form of a shimmering flame coming and it's going to take me a while to finish it so I suggest merging this in the meantime. There's no harm in having more than just one spinner anyway, so it should be alright.

I haven't added the color of the circle yet but it should be easy enough. Although I am not sure it's so much needed to change the color of the spinner. If we pass a raw color than it's probably not going to look quite as nice, but I can tinker with maybe some colorized versions. 