### PR TITLE
fix: added seed storage to the database

### DIFF
--- a/giddy-banana/config/config.json
+++ b/giddy-banana/config/config.json
@@ -5,7 +5,8 @@
     "database": "db",
     "host": "localhost",
     "dialect": "mysql",
-    "port": "3306"
+    "port": "3306",
+    "seederStorage": "sequelize"
   },
   "test": {
     "username": "root",


### PR DESCRIPTION
* added 'sequelize' seed storage to the sequelize config
* will now store the seed files in the database in the same manner as
  migrations, in effect rerunning a seed command won't try to add the
  same seed file twice

Closes #124

This fixes errors when running `npm run dev`. You will have to remove all the previous seeded records in order for this to start working properly (I just reset my database container - down and up).