### PR TITLE
29 optional section

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,7 +2,8 @@
   <main>
     <wof-header/>
     <div class="main-wrapper">
-      <router-view msg="This is a basic frontend"></router-view>
+      <!--<router-view msg="This is a basic frontend"></router-view>-->
+      <wof-optional-section></wof-optional-section>
     </div>
     <wof-footer/>
   </main>
@@ -11,9 +12,10 @@
 <script>
 import WofFooter from './components/WofFooter.vue';
 import WofHeader from './components/WofHeader.vue';
+import WofOptionalSection from './components/WofOptionalSection.vue';
 
 export default {
-  components: { WofFooter, WofHeader },
+  components: { WofFooter, WofHeader, WofOptionalSection },
   name: "App",
 };
 </script>
@@ -36,7 +38,7 @@ body {
       justify-content: center;
       min-height: 90vh;
       background-color: @tertiary-color;
-      padding: 2em 4em;
+      // padding: 2em 4em;
     }
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,8 +2,7 @@
   <main>
     <wof-header/>
     <div class="main-wrapper">
-      <!--<router-view msg="This is a basic frontend"></router-view>-->
-      <wof-optional-section></wof-optional-section>
+      <router-view msg="This is a basic frontend"></router-view>
     </div>
     <wof-footer/>
   </main>
@@ -12,10 +11,9 @@
 <script>
 import WofFooter from './components/WofFooter.vue';
 import WofHeader from './components/WofHeader.vue';
-import WofOptionalSection from './components/WofOptionalSection.vue';
 
 export default {
-  components: { WofFooter, WofHeader, WofOptionalSection },
+  components: { WofFooter, WofHeader },
   name: "App",
 };
 </script>

--- a/frontend/src/components/WofOptionalSection.vue
+++ b/frontend/src/components/WofOptionalSection.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="optional">
-    <div class="optional__content"></div>
+      <div class="optional__content" v-if="isContentVisible">
+        <slot></slot>
+      </div>
     <div class="optional__button-bar">
       <div class="optional__toggle-button">
-        <wof-icon icon="wof-down" :size="2"></wof-icon>
+        <wof-icon :icon="toggleIcon" :size="2" @click="toggleContent"></wof-icon>
       </div>
     </div>
   </div>
@@ -12,6 +14,24 @@
 <script>
 export default {
   name: "WofOptionalSection",
+  data() {
+    return {
+      isContentVisible: true
+    };
+  },
+  methods: {
+    toggleContent() {
+      this.isContentVisible = !this.isContentVisible;
+    }
+  },
+  computed: {
+    toggleIcon() {
+      if(this.isContentVisible) {
+        return 'wof-up';
+      }
+      return 'wof-down';
+    }
+  }
 };
 </script>
 
@@ -25,6 +45,8 @@ export default {
   width: 100%;
 
   .optional__content {
+    display: flex;
+    justify-content: center;
     width: 100%;
     height: 300px;
     background-color: @secondary-color;

--- a/frontend/src/components/WofOptionalSection.vue
+++ b/frontend/src/components/WofOptionalSection.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="optional">
+    <div class="optional__content"></div>
+    <div class="optional__button-bar">
+      <div class="optional__toggle-button">
+        <wof-icon icon="wof-down" :size="2"></wof-icon>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "WofOptionalSection",
+};
+</script>
+
+<style lang="less">
+@import "./common.less";
+
+.optional {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+
+  .optional__content {
+    width: 100%;
+    height: 300px;
+    background-color: @secondary-color;
+  }
+
+  .optional__button-bar {
+      display: flex;
+      justify-content: center;
+      background-color: @secondary-color;
+      width: 100%;
+      height: 22px;
+
+    .optional__toggle-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      width: 30px;
+      height: 30px;
+      padding: 7px;
+      background-color: @primary-accent-color;
+      color: @primary-bright-text-color;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
closes #29 

I tested it with this code: 
`<template>
  <main>
    <wof-header/>
    <div class="main-wrapper">
      <!--<router-view msg="This is a basic frontend"></router-view>-->
      <wof-optional-section>
        <div style="display: flex; flex-direction: column;">
          <h2>Content</h2>
          <p>Text</p>
        </div>
      </wof-optional-section>
    </div>
    <wof-footer/>
  </main>
</template>

<script>
import WofFooter from './components/WofFooter.vue';
import WofHeader from './components/WofHeader.vue';
import WofOptionalSection from './components/WofOptionalSection.vue';

export default {
  components: { WofFooter, WofHeader, WofOptionalSection },
  name: "App",
};
</script>`