### PR TITLE
add: added dynamo db to aws

### DIFF
--- a/.github/workflows/seed-dynamo.yaml
+++ b/.github/workflows/seed-dynamo.yaml
@@ -17,5 +17,10 @@ jobs:
         with:
           node-version: '16.x'
           cache: 'npm'
-      - run: npm ci
-      - run: node seedMostViewedArticlesTable.js
+      - name: Set up the package dependencies
+        run: npm ci
+      - name: Seed the DynamoDB table
+        run: node seedMostViewedArticlesTable.js
+        env:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/seed-dynamo.yaml
+++ b/.github/workflows/seed-dynamo.yaml
@@ -1,0 +1,21 @@
+name: Seed DynamoDB tables
+
+on:
+  workflow_dispatch:
+
+jobs:
+  viewsTable:
+    name: Seed the most viewed articles table.
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: wikimedia-requests
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: node seedMostViewedArticlesTable.js

--- a/amazon-architecture/DynamoDB.yaml
+++ b/amazon-architecture/DynamoDB.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  mostViewedTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        -
+          AttributeName: "date"
+          AttributeType: "S"
+        -
+          AttributeName: "rank"
+          AttributeType: "N"
+      KeySchema:
+        -
+          AttributeName: "date"
+          KeyType: "HASH"
+        -
+          AttributeName: "rank"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+      TableName: MostViewedArticles

--- a/amazon-architecture/DynamoDB.yaml
+++ b/amazon-architecture/DynamoDB.yaml
@@ -18,6 +18,20 @@ Resources:
           AttributeName: "rank"
           KeyType: "RANGE"
       ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
       TableName: MostViewedArticles
+      StreamSpecification:
+        StreamViewType: "NEW_IMAGE"
+
+Outputs:
+  dynamoID:
+    Description: The reference to the dynamoDB MostViewedArticles table
+    Value: !GetAtt mostViewedTable.Arn
+    Export:
+      Name: "mostViewedTable"
+  dynamoStreamID:
+    Description: The ARN of the MostViewedArticles table data stream
+    Value: !GetAtt mostViewedTable.StreamArn
+    Export:
+      Name: "mostViewedTableStream"

--- a/wikimedia-requests/package-lock.json
+++ b/wikimedia-requests/package-lock.json
@@ -1,9 +1,191 @@
 {
   "name": "@wof/wiki-requests",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@wof/wiki-requests",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "aws-sdk": "^2.1048.0",
+        "axios": "^0.24.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1048.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1048.0.tgz",
+      "integrity": "sha512-mVwWo+Udiuc/yEZ/DgJQGqOEtfiQjgUdtshx/t6ISe3+jW3TF9hUACwADwx2Sr/fuJyyJ3QD5JYLt5Cw35wQpA==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
+    "aws-sdk": {
+      "version": "2.1048.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1048.0.tgz",
+      "integrity": "sha512-mVwWo+Udiuc/yEZ/DgJQGqOEtfiQjgUdtshx/t6ISe3+jW3TF9hUACwADwx2Sr/fuJyyJ3QD5JYLt5Cw35wQpA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "axios": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
@@ -12,10 +194,88 @@
         "follow-redirects": "^1.14.4"
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/wikimedia-requests/package.json
+++ b/wikimedia-requests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wof/wiki-requests",
   "version": "0.0.1",
-  "description": "List of utilities supporting contacts with the WikiMedia API",
+  "description": "List of utilities supporting contacts with the WikiMedia API, processing the data and passing it to the AWS architecture.",
   "main": "requests.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/kpagacz/wiki-on-fire#readme",
   "dependencies": {
+    "aws-sdk": "^2.1048.0",
     "axios": "^0.24.0"
   },
   "type": "module"

--- a/wikimedia-requests/requests.js
+++ b/wikimedia-requests/requests.js
@@ -40,7 +40,7 @@ const getMostViewedArticles = async (year, month, day) => {
       return response.data.items[0].articles;
     })
     .catch((error) => {
-      throw error;
+      throw new Error("Error from the WikiMedia API: " + error.response.data.detail);
     });
   return articles;
 };

--- a/wikimedia-requests/seedMostViewedArticlesTable.js
+++ b/wikimedia-requests/seedMostViewedArticlesTable.js
@@ -1,0 +1,60 @@
+/**
+ * Seeds the DynamoDB table with the first 100 of the most viewed articles from each of the past 100 days.
+ * Uses AWS_ACCESS_KEY and AWS_SECRET_KEY environmental variables to authenticate to AWS.
+ */
+
+import { getMostViewedArticles } from "./requests.js";
+import AWS from "aws-sdk";
+
+const DAYS_LIMIT = 100;
+const ARTICLES_LIMIT = 100;
+
+const config = {
+  region: "eu-central-1",
+  accessKeyId: process.env.AWS_ACCESS_KEY,
+  secretAccessKey: process.env.AWS_SECRET_KEY,
+};
+const dynamo = new AWS.DynamoDB(config);
+dynamo.listTables({}, function (err, data) {
+  if (err) console.log(err, err.stack);
+  // an error occurred
+  else if (!data.TableNames.includes("MostViewedArticles"))
+    throw new Error("MostViewedArticles table not available");
+});
+
+const now = new Date().getTime();
+for (let i = 0; i < DAYS_LIMIT; i++) {
+  const date = new Date(now - i * 24 * 60 * 60 * 1000);
+  getMostViewedArticles(date.getFullYear(), date.getMonth() + 1, date.getDate())
+    .then((data) => {
+      data.slice(0, ARTICLES_LIMIT).forEach((article) => {
+        const params = {
+          Item: {
+            date: {
+              S: date.toISOString().slice(0, 10),
+            },
+            rank: {
+              N: article.rank.toString(),
+            },
+            article: {
+              S: article.article,
+            },
+            views: {
+              N: article.views.toString(),
+            },
+          },
+          ReturnConsumedCapacity: "TOTAL",
+          TableName: "MostViewedArticles",
+        };
+        dynamo.putItem(params, function (err, data) {
+          if (err) console.error("Putting item unsuccessful. " + err.message);
+        });
+      });
+      {
+      }
+    })
+    .catch((error) => {
+      console.error(error.message);
+    });
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+}


### PR DESCRIPTION
* added a DynamoDB cloud formation yaml
* added a script to wikimedia-requests, which downloads articles from wikimedia and puts them in dynamodb
* added a github actions workflow dispatch on demand, which runs the above script
Closes #167

How to test:
* remove all dynamo db instances from AWS
* use cloud formation on aws to create the dynamo db instance (with the new yaml file)
* try running the workflow (it might be possible even if it's just a PR)
* if running a PR fails, you can run the script on its own if you provide it valid access key and secret key (you can generate those from AWS IAM service)

The expected behaviour:
* a new table MostViewedArticles is created on AWS
* this table is populated with the top 100 most viewed articles from each of the past 100 days

This is just seeding the table. There is still the lambda to update it every day (although worst case scenario, I could just copy the same script to the lambda and hopefully it would work).