### PR TITLE
add: improved error messages from the /api/users POST endpoint

### DIFF
--- a/frontend/src/httpLayers/accountActions.http.js
+++ b/frontend/src/httpLayers/accountActions.http.js
@@ -11,6 +11,9 @@ import wofApi from "./wofApi.js";
  * 1. The user couldn't have been created.
  * 2. The connection to the backend service was refused.
  * 3. An unexpected error.
+ * If the user could not have been created, the error
+ * contains the property `path` specifying what field
+ * of the form was invalid. Possible values: `username`, `password`, `email`.
  *
  * @example
  * await registerUser("firstuser", "theirpassword", "theirmail@mail.com");
@@ -23,7 +26,9 @@ async function registerUser(username, password, email) {
     })
     .catch((error) => {
       if (error.response) {
-        throw new Error(`${error.response.data.message}`);
+        const err = new Error(`${error.response.data.message}`);
+        err.path = error.response.data.path;
+        throw err;
       } else if (error.request) {
         throw new Error("Service refused connection");
       } else {
@@ -73,7 +78,7 @@ async function deleteUser(username) {
  * 1. The account information could not have been udpated.
  * 2. The connection to the backend service was refused.
  * 3. An unexpected error.
-  */
+ */
 async function updateUser(username, updatedDetails) {
   if (!(username instanceof String) && typeof username !== "string")
     throw new Error("username must be a string");

--- a/giddy-banana/controllers/usersController.js
+++ b/giddy-banana/controllers/usersController.js
@@ -26,7 +26,7 @@ async function postUsers(req, res) {
     );
     res.status(201).json(createdUser);
   } catch (e) {
-    res.status(400).send({ message: e.message });
+    res.status(400).send({message: e.message, path: e.path});
   }
 }
 

--- a/giddy-banana/models/userModel.cjs
+++ b/giddy-banana/models/userModel.cjs
@@ -1,7 +1,5 @@
 "use strict";
-const {
-  Model
-} = require("sequelize");
+const { Model } = require("sequelize");
 module.exports = (sequelize, DataTypes) => {
   /**
    * Represents a single user in the database.
@@ -20,29 +18,38 @@ module.exports = (sequelize, DataTypes) => {
       models.User.belongsToMany(models.Article, { through: "Recommend" });
       models.User.belongsToMany(models.Article, { through: "Favourite" });
     }
-  };
-  User.init({
-    username: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      unique: true
+  }
+  User.init(
+    {
+      username: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          is: {
+            args: /^.+@.+$/,
+            msg: "Invalid e-mail",
+          },
+        },
+      },
+      account_type: DataTypes.INTEGER,
+      account_status: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
     },
-    password: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
-    email: {
-      type: DataTypes.STRING,
-      allowNull: false
-    },
-    account_type: DataTypes.INTEGER,
-    account_status: {
-      type: DataTypes.INTEGER,
-      allowNull: false
+    {
+      sequelize,
+      modelName: "User",
     }
-  }, {
-    sequelize,
-    modelName: "User",
-  });
+  );
   return User;
 };


### PR DESCRIPTION
Closes #101

How to test:
1. Open the register page and try inputting: duplicated user name, invalid email, too short or too long password (< 8 or > 20 characters)
2. The error should be now much better

From a technical pov: the http layer error now had an additional property - path - specifying the invalid field.